### PR TITLE
feat(colors): add first draft of color theme

### DIFF
--- a/src/components/atoms/button/button.stories.tsx
+++ b/src/components/atoms/button/button.stories.tsx
@@ -5,5 +5,7 @@ export default {
   component: Button,
 };
 
-export const primaryButton = (props: ButtonProps) => <Button variant="primary">Default button</Button>;
-export const secondaryButton = (props: ButtonProps) => <Button variant="secondary">Default button</Button>;
+export const defaultButton = (props: ButtonProps) => <Button>Default button</Button>;
+export const orangeButton = (props: ButtonProps) => <Button variant="orange">Orange Button</Button>;
+export const greenButton = (props: ButtonProps) => <Button variant="green">Green Button</Button>;
+export const redButton = (props: ButtonProps) => <Button variant="red">Red Button</Button>;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,22 +1,92 @@
 import { Theme } from "theme-ui";
 
+const blue = {
+  1: "#0D2546",
+  2: "#11325E",
+  3: "#153E75",
+  4: "#2C5183",
+  5: "#446591",
+  6: "#5B789E",
+  7: "#738BAC",
+  8: "#8A9FBA",
+  9: "#A1B2C8",
+  10: "#B9C5D6",
+  11: "#D0D8E3",
+  12: "#E8ECF1",
+};
+const orange = {
+  1: "#966E35",
+  2: "#C89247",
+  3: "#FAB759",
+  4: "#FBBE6A",
+  5: "#FBC57A",
+  6: "#FCCD8B",
+  7: "#FCD49B",
+  8: "#FDDBAC",
+  9: "#FDE2BD",
+  10: "#FEE9CD",
+  11: "#FEF1DE",
+  12: "#FFF8EE",
+};
+
+const green = {
+  1: "#425845",
+  2: "#698C6E",
+  3: "#83AF89",
+  4: "#8FB795",
+  5: "#9CBFA1",
+  6: "#A8C7AC",
+  7: "#B5CFB8",
+  8: "#C1D7C4",
+  9: "#CDDFD0",
+  10: "#DAE7DC",
+  11: "#E6EFE7",
+  12: "#F3F7F3",
+};
+
+const red = {
+  1: "#811722",
+  2: "#AC1E2D",
+  3: "#D72638",
+  4: "#DB3C4C",
+  5: "#DF5160",
+  6: "#E36774",
+  7: "#E77D88",
+  8: "#EB939C",
+  9: "#EFA8AF",
+  10: "#F3BEC3",
+  11: "#F7D4D7",
+  12: "#FBE9EB",
+};
+
+const gray = {
+  1: "#2E3440",
+  2: "#3D4555",
+  3: "#4C566A",
+  4: "#5E6779",
+  5: "#707888",
+  6: "#828997",
+  7: "#949AA6",
+  8: "#A6ABB5",
+  9: "#B7BBC3",
+  10: "#C9CCD2",
+  11: "#DBDDE1",
+  12: "#EDEEF0",
+};
+
 export const colors: Theme["colors"] = {
   text: "#000",
-  background: "#fff",
-  primary: { __default: "#153e75", light: "#2c5183", dark: "#133869" },
-  secondary: { __default: "#F98B00", light: "#fa971a", dark: "#e07d00" },
-  highlight: "#EFEFFE",
-  muted: "#f6f6ff",
+  background: gray[12],
+  primary: blue[3],
+  secondary: orange[3],
+  accent: green[3],
+  highlight: orange[10],
+  muted: blue[11],
+  blue,
+  orange,
+  green,
+  red,
+  gray,
   onlineBlue: "#0D5474",
   onlineOrange: "#F9B759",
-  modes: {
-    dark: {
-      text: "#fff",
-      background: "#000",
-      primary: "#0fc",
-      secondary: "#0cf",
-      highlight: "#EFEFFE",
-      muted: "#011",
-    },
-  },
 };

--- a/src/styles/components/button.ts
+++ b/src/styles/components/button.ts
@@ -1,17 +1,19 @@
 import type { Theme } from "theme-ui";
 
-const getButtonColors = (variant: string) => ({
-  variant: "buttons.base",
-  bg: variant,
-  "&:hover": {
-    bg: `${variant}.light`,
-    transform: "translateY(-1px)",
-  },
-  "&:active": {
-    bg: `${variant}.dark`,
-    transform: "translateY(2px)",
-  },
-});
+const getButtonColors = (variant: string) => {
+  return {
+    variant: "buttons.base",
+    bg: `${variant}.3`,
+    "&:hover": {
+      bg: `${variant}.4`,
+      transform: "translateY(-1px)",
+    },
+    "&:active": {
+      bg: `${variant}.5`,
+      transform: "translateY(2px)",
+    },
+  };
+};
 
 const buttons: Theme["buttons"] = {
   base: {
@@ -19,8 +21,13 @@ const buttons: Theme["buttons"] = {
     transition: "0.2s ease-in-out",
     cursor: "pointer",
   },
-  primary: getButtonColors("primary"),
-  secondary: getButtonColors("secondary"),
+  blue: getButtonColors("blue"),
+  orange: getButtonColors("orange"),
+  green: getButtonColors("green"),
+  red: getButtonColors("red"),
+  primary: {
+    variant: "buttons.blue",
+  },
 };
 
 export default buttons;


### PR DESCRIPTION
I've added the colors gray, blue, green, red and orange.

Blue will be used as the brand and info color
Green will be used for success
Red will be used for errors
Orange will be used as a secondary color, and also as a warning color

![image](https://user-images.githubusercontent.com/41551253/140831911-6544ec55-bb67-4b27-9f33-46a22b406cd1.png)
