### PR TITLE
ConnectedCircles: Centered numeration

### DIFF
--- a/src/components/molecules/ConnectedCircles.tsx
+++ b/src/components/molecules/ConnectedCircles.tsx
@@ -18,7 +18,7 @@ interface ConnectedCircleProps {
 
 export const ConnectedCircles: React.FC<ConnectedCircleProps> = ({ size, lineColor, circleColor }) => {
   return (
-    <Box sx={{ minWidth: size, display: "flex", justifyContent: "center", alignItems: "center", margin: "auto" }}>
+    <Box sx={{ minWidth: size, display: "flex", justifyContent: "center", alignItems: "center", margin: "auto", textAlign: "center" }}>
       <Circle size={size / 15} color={circleColor}>
         1
       </Circle>


### PR DESCRIPTION
The ConnectedCircles-component had a numeration where the text was not centered correctly.